### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ What is it for?
 -------------------
 Checks a given IBAN (International Banking Account Number) against ISO 13616:2007.
 
-![Build Status](https://travis-ci.org/HHuckebein/IBANCheck.svg?branch=master) ![Cocoapods Version](https://img.shields.io/cocoapods/v/IBANCheck.svg)
+![Build Status](https://travis-ci.org/HHuckebein/IBANCheck.svg?branch=master) ![CocoaPods Version](https://img.shields.io/cocoapods/v/IBANCheck.svg)
 
 ### CocoaPods
 
-If you want to add IBANCheck using Cocoapods then add the following dependency
+If you want to add IBANCheck using CocoaPods then add the following dependency
 to your Podfile.
 
 ```ruby


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
